### PR TITLE
Fix broken links in docs plus other minor changes

### DIFF
--- a/docs/adding-alerts.md
+++ b/docs/adding-alerts.md
@@ -17,7 +17,7 @@ addresses are on the linked GitHub profiles.
 
 1. Open your editor on a file named `_alerts/YYYY-MM-DD-short-title.md`
    (the alert will appear as
-<https://btcinformation.org/en/alert/YYYY-MM-DD-short-title>).
+https://btcinformation.org/en/alert/YYYY-MM-DD-short-title).
 
 2. Paste the following text into the top of the file:
 ```

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -22,7 +22,7 @@ translating or improving existing translations.
 \_translations/ and from the root of the git repository run
 ./\_contrib/updatetx.rb to update layouts and templates for this language. You
 should also make sure that no url has been changed by translators. If any page
-needs to be moved, please add [redirections](docs/miscellaneous.md#redirections).
+needs to be moved, please add [redirections](miscellaneous.md#redirections).
 
 **Add a new language**: You can put the language file from Transifex in
 \_translations and add the language in \_config.yml in the right display order

--- a/docs/become-a-contributor.md
+++ b/docs/become-a-contributor.md
@@ -11,7 +11,7 @@ Here are some ways you can help:
     with a short list of your interests and skills, and they will email you when
     there's an issue or PR that could use your attention.
 
-* Help [write new documentation](docs/contributing-to-developer-documentation.md)
+* Help [write new documentation](contributing-to-developer-documentation.md)
   for the [developer documentation pages](https://btcinformation.org/en/developer-documentation),
   or **[review PRs adding new documentation](https://github.com/achow101/btcinformation.org/pulls?q=is%3Apr+is%3Aopen+label%3A%22Dev+Docs%22).**
   You don't need to be a Bitcoin expert to review a PR---these docs are written
@@ -19,17 +19,13 @@ Here are some ways you can help:
   incomplete. If you review a PR and don't find any problems worth commenting
   about, leave a "Looks Good To Me (LGTM)" comment.
 
-* [Submit new wallets](docs/managing-wallets.md)
+* [Submit new wallets](managing-wallets.md)
   for the [Choose Your Wallet page](https://btcinformation.org/en/choose-your-wallet) or
   help us [review wallet submissions](https://github.com/achow101/btcinformation.org/pulls?q=is%3Aopen+label%3Awallet+is%3Apr).
 
-* [Translate Bitcoin.org into another language](docs/assisting-with-translations.md)
+* [Translate Btcinformation.org into another language](assisting-with-translations.md)
   using [Transifex](https://www.transifex.com/projects/p/btcinformationorg/) or help
   review new and updated translations.
-
-* Add Bitcoin events to the [events page](https://btcinformation.org/en/events)
-  either by editing `_events.yml` according to the [event instructions](docs/adding-events-release-notes-and-alerts.md)
-  or by filling in a [pre-made events issue](https://github.com/achow101/btcinformation.org/issues/new?title=New%20event&body=%20%20%20%20-%20date%3A%20YYYY-MM-DD%0A%20%20%20%20%20%20title%3A%20%22%22%0A%20%20%20%20%20%20venue%3A%20%22%22%0A%20%20%20%20%20%20address%3A%20%22%22%0A%20%20%20%20%20%20city%3A%20%22%22%0A%20%20%20%20%20%20country%3A%20%22%22%0A%20%20%20%20%20%20link%3A%20%22%22).
 
 * Help improve Bitcoin.org another way. Email volunteer coordinators Andrew Chow ([admin@btcinformation.org](mailto:admin@btcinformation.org))
   or Dave Harding ([dave@dtrt.org](mailto:dave@dtrt.org)) to let us know how

--- a/docs/contributing-to-developer-documentation.md
+++ b/docs/contributing-to-developer-documentation.md
@@ -1,9 +1,9 @@
 ## Developer Documentation
 
 Most parts of the documentation can be found in the
-[_includes](_includes)
+[_includes](../_includes)
 directory. Updates, fixes and improvements are welcome and can submitted using
-[pull requests](docs/working-with-github.md)
+[pull requests](working-with-github.md)
 on GitHub.
 
 **Mailing List**: General discussions can take place on the

--- a/docs/setting-up-your-environment.md
+++ b/docs/setting-up-your-environment.md
@@ -76,7 +76,7 @@ Use that program to install bundle:
 **Install the Ruby dependencies**
 
 Ensure you checked out the site repository as described in [Working with
-GitHub](docs/working-with-github.md).
+GitHub](working-with-github.md).
 Then change directory to the top-level of your local repository (replace
 `btcinformation.org` with the full path to your local repository clone):
 


### PR DESCRIPTION
I checked all of the links in the docs directory and fixed any broken ones, except for the Transfinex link (in `assisting-with-translations.md` and `becoming-a-contributor.md`). I couldn't find a proper url for that.

In `becoming-a-contributor.md`, I changed Bitcoin.org to Btcinformation.org and removed the line about events. I also removed the hyperlink from the example url in `adding-alerts.md` as it isn't a real url.