### PR TITLE
js/base: fix broken mobile menu

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -145,8 +145,7 @@ function mobileMenuShow(e) {
   // Show the mobile menu when the visitors touch the menu icon.
   var show = function() {
     var mm = document.getElementById('menusimple');
-    var ml = document.getElementById('langselect');
-    mm.style.display = ml.style.display = (mm.style.display === 'block') ? '' : 'block';
+    mm.style.display = (mm.style.display === 'block') ? '' : 'block';
     addClass(mm, 'menutap');
     cancelEvent(e);
   };


### PR DESCRIPTION
Close #5 

I've only lightly tested this with the fast preview mode and Firefox in responsive testing mode, but it seems to work.

Edit: oh, this should be reverted when we restore multiple languages.  It should be a clean revert.