### PR TITLE
404: only redirect to the English homepage for now

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,7 +9,7 @@ title: Bitcoin
 ---
 <script>
 //Auto redirect to the appropriate language
-var langs={};{% for lang in site.langs %}{% if lang[0] != page.lang %}langs['{{ lang[0] }}']=true;{% endif %}{% endfor %}
+var langs={};
 var lang=(navigator.language)?navigator.language:navigator.userLanguage;
 lang=lang.split('_')[0];
 if(!langs[lang])lang='en';


### PR DESCRIPTION
This fixes the redirection infinite loop described in #6 (although that issue seems to also have a general comment about languages, which were deliberately disabled).

Lightly tested on desktop Firefox.

CC: @TheRec (original bug reporter)