### PR TITLE
Remove redundant divs from devdocs layout

### DIFF
--- a/_layouts/devdoc-category.md
+++ b/_layouts/devdoc-category.md
@@ -35,8 +35,6 @@ end_of_page: |
   <ul class="goback"><li><a href="/{{ page.lang }}/developer-documentation">{% translate navigationreturn developer-documentation %}</a></li></ul>
   <ul class="reportissue"><li><a href="{{site.repo}}/issues/new" onmouseover="updateIssue(event);">{% translate navigationreport developer-documentation %}</a></li></ul>
   <ul class="editsource"><li><a href="{{site.repo}}/tree/master/_includes" onmouseover="updateSource(event);">{% translate navigationedit developer-documentation %}</a></li></ul>
-  </div>
-  </div>
 
 </div></div>
 <div markdown="1" class="toccontent">


### PR DESCRIPTION
Closes #15 

I reproduced the original issue and found this to fix it.  Moderately tested (but I didn't run the automated tests that check HTML validity[1]---Travis should do that for me).

CC: @jnewbery (bug reporter, thanks!)

[1] Wait, if we automatically check validity, why didn't the tests catch it before?  Because Markdown also tries to enforce valid HTML and so (in certain cases) turns out-of-place tags in to display text.  :man_facepalming: 