### PR TITLE
Re-enable deterministic site builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,9 @@ clean:
 ## This should not affect webpage output.
 build:
 	$S export LC_ALL=en_US.UTF-8 ; export ENABLED_LANGS="en" ; bundle exec jekyll build 2>&1 | tee $(JEKYLL_LOG)
-	$S grep -r -L 'Note: this file is built non-deterministically' _site/ \
+	$S grep -r -L 'Note: this file is built non-deterministically' _site \
 	  | egrep -v 'sha256sums.txt' \
-	  | sort \
+	  | LC_ALL=en_US.UTF-8 sort -f \
 	  | xargs -d '\n' sha256sum > _site/sha256sums.txt
 	$S git log -1 --format="%H" > _site/commit.txt
 

--- a/_alerts/2015-10-12-upnp-vulnerability.md
+++ b/_alerts/2015-10-12-upnp-vulnerability.md
@@ -11,7 +11,7 @@ active: false
 
 ## Summary
 
-![Disabling UPnP in the GUI](/img/alerts/disable_upnp.png?{{site.time | date: '%s'}})
+![Disabling UPnP in the GUI](/img/alerts/disable_upnp.png)
 
 Either
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
+timezone: UTC
+
 langsorder:
 - 'id'
 - 'da'

--- a/_data/devdocs/en/examples/p2p_networking.md
+++ b/_data/devdocs/en/examples/p2p_networking.md
@@ -386,19 +386,19 @@ bb3183301d7a1fb3bd174fcfa40a2b65 ... Hash #2
 We parse the above `merkleblock` message using the following
 instructions.  Each illustration is described in the paragraph below it.
 
-![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-001.svg?{{site.time | date: '%s'}})
+![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-001.svg)
 
 We start by building the structure of a merkle tree based on the number
 of transactions in the block.
 
-![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-002.svg?{{site.time | date: '%s'}})
+![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-002.svg)
 
 The first flag is a 1 and the merkle root is (as always) a non-TXID
 node, so we will need to compute the hash later based on this node's
 children. Accordingly, we descend into the merkle root's left child and
 look at the next flag for instructions.
 
-![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-003.svg?{{site.time | date: '%s'}})
+![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-003.svg)
 
 The next flag in the example is a 0 and this is also a non-TXID node, so
 we apply the first hash from the `merkleblock` message to this node. We
@@ -408,43 +408,43 @@ transactions that match our filter, so we don't need them. We go back up
 to the merkle root and then descend into its right child and look at the
 next (third) flag for instructions.
 
-![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-004.svg?{{site.time | date: '%s'}})
+![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-004.svg)
 
 The third flag in the example is another 1 on another non-TXID node, so
 we descend into its left child.
 
-![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-005.svg?{{site.time | date: '%s'}})
+![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-005.svg)
 
 The fourth flag is also a 1 on another non-TXID node, so we descend
 again---we will always continue descending until we reach a TXID node or
 a non-TXID node with a 0 flag (or we finish filling out the tree).
 
-![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-006.svg?{{site.time | date: '%s'}})
+![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-006.svg)
 
 Finally, on the fifth flag in the example (a 1), we reach a TXID node.
 The 1 flag indicates this TXID's transaction matches our filter and
 that we should take the next (second) hash and use it as this node's
 TXID. 
 
-![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-007.svg?{{site.time | date: '%s'}})
+![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-007.svg)
 
 The sixth flag also applies to a TXID, but it's a 0 flag, so this
 TXID's transaction doesn't match our filter; still, we take the next
 (third) hash and use it as this node's TXID.
 
-![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-008.svg?{{site.time | date: '%s'}})
+![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-008.svg)
 
 We now have enough information to compute the hash for the fourth node
 we encountered---it's the hash of the concatenated hashes of the two
 TXIDs we filled out.
 
-![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-009.svg?{{site.time | date: '%s'}})
+![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-009.svg)
 
 Moving to the right child of the third node we encountered, we fill it
 out using the seventh flag and final hash---and discover there are no
 more child nodes to process.
 
-![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-011.svg?{{site.time | date: '%s'}})
+![Parsing A MerkleBlock](/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-011.svg)
 
 We hash as appropriate to fill out the tree.  Note that the eighth flag is
 not used---this is acceptable as it was required to pad out a flag byte.

--- a/_data/devdocs/en/examples/payment_processing.md
+++ b/_data/devdocs/en/examples/payment_processing.md
@@ -54,7 +54,7 @@ not used in this program.)
 The full sequence of events is illustrated below, starting with the
 spender clicking a `bitcoin:` URI or scanning a `bitcoin:` QR code.
 
-![BIP70 Payment Protocol](/img/dev/en-payment-protocol.svg?{{site.time | date: '%s'}})
+![BIP70 Payment Protocol](/img/dev/en-payment-protocol.svg)
 
 For the script to use the protocol buffer, you will need a copy of
 Google's Protocol Buffer compiler (`protoc`), which is available in most
@@ -221,7 +221,7 @@ X.509 certificate and how each certificate (except the
 root certificate) would be loaded into the [X509Certificates][]{:#term-x509certificates}{:.term} protocol
 buffer message.
 
-![X509Certificates Loading Order](/img/dev/en-cert-order.svg?{{site.time | date: '%s'}})
+![X509Certificates Loading Order](/img/dev/en-cert-order.svg)
 
 To be specific, the first certificate provided must be the
 X.509 certificate corresponding to the private SSL key which will make the
@@ -469,6 +469,6 @@ because it would add an extraneous newline.
 The following screenshot shows how the authenticated PaymentDetails
 created by the program above appears in the GUI from Bitcoin Core 0.9.
 
-![Bitcoin Core Showing Validated Payment Request](/img/dev/en-btcc-payment-request.png?{{site.time | date: '%s'}})
+![Bitcoin Core Showing Validated Payment Request](/img/dev/en-btcc-payment-request.png)
 
 {% endautocrossref %}

--- a/_data/devdocs/en/examples/transactions.md
+++ b/_data/devdocs/en/examples/transactions.md
@@ -241,7 +241,7 @@ second argument (a JSON object) creates the output with the address
 (public key hash) and number of bitcoins we want to transfer.
 We save the resulting raw format transaction to a shell variable.
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
  **Warning:** `createrawtransaction` does not automatically create change
 outputs, so you can easily accidentally pay a large transaction fee. In
 this example, our input had 50.0000 bitcoins and our output
@@ -461,7 +461,7 @@ Use the `dumpprivkey` RPC to get the private keys corresponding to the
 public keys used in the two UTXOs we will be spending.  We need
 the private keys so we can sign each of the inputs separately.
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
  **Warning:** Users should never manually manage private keys on mainnet.
 As dangerous as raw transactions are (see warnings above), making a
 mistake with a private key can be much worse---as in the case of a HD
@@ -628,7 +628,7 @@ Offline signing is safe. However, in this example we will also be
 spending an output which is not part of the block chain because the
 transaction containing it has never been broadcast. That can be unsafe:
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
  **Warning:** Transactions which spend outputs from unconfirmed
 transactions are vulnerable to transaction malleability. Be sure to read
 about transaction malleability and adopt good practices before spending
@@ -804,7 +804,7 @@ Transaction subsection. If you've read the [Transaction section][transaction] of
 the guide, you may know why the call fails and leaves the raw
 transaction hex unchanged.
 
-![Old Transaction Data Required To Be Signed](/img/dev/en-signing-output-to-spend.svg?{{site.time | date: '%s'}})
+![Old Transaction Data Required To Be Signed](/img/dev/en-signing-output-to-spend.svg)
 
 As illustrated above, the data that gets signed includes the txid and
 vout from the previous transaction.  That information is included in the
@@ -1023,7 +1023,7 @@ redeem script.
 The P2SH address is returned along with the redeem script which must be
 provided when we spend satoshis sent to the P2SH address.
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
  **Warning:** You must not lose the redeem script, especially if you
 don't have a record of which public keys you used to create the P2SH
 multisig address. You need the redeem script to spend any bitcoins sent
@@ -1177,7 +1177,7 @@ transaction, the same way we got private keys in the Complex Raw
 Transaction subsection. Recall that we created a 2-of-3 multisig pubkey script,
 so signatures from two private keys are needed.
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
  **Reminder:** Users should never manually manage private keys on
 mainnet. See the warning in the [complex raw transaction section][devex
 complex raw transaction].

--- a/_data/devdocs/en/guides/block_chain.md
+++ b/_data/devdocs/en/guides/block_chain.md
@@ -28,7 +28,7 @@ the consensus rules used by Bitcoin Core.
 
 {% autocrossref %}
 
-![Block Chain Overview](/img/dev/en-blockchain-overview.svg?{{site.time | date: '%s'}})
+![Block Chain Overview](/img/dev/en-blockchain-overview.svg)
 
 The illustration above shows a simplified version of a block chain.
 A [block][/en/glossary/block]{:#term-block}{:.term} of one or more new transactions
@@ -49,7 +49,7 @@ transaction spends the satoshis previously received in one or more earlier
 transactions, so the input of one transaction is the output of a
 previous transaction.
 
-![Transaction Propagation](/img/dev/en-transaction-propagation.svg?{{site.time | date: '%s'}})
+![Transaction Propagation](/img/dev/en-transaction-propagation.svg)
 
 A single transaction can create multiple outputs, as would be
 the case when sending to multiple addresses, but each output of
@@ -166,7 +166,7 @@ by their [block height][/en/glossary/block-height]{:#term-block-height}{:.term}-
 block (block 0, most commonly known as the [genesis block][/en/glossary/genesis-block]{:#term-genesis-block}{:.term}). For example,
 block 2016 is where difficulty could have first been adjusted.
 
-![Common And Uncommon Block Chain Forks](/img/dev/en-blockchain-fork.svg?{{site.time | date: '%s'}})
+![Common And Uncommon Block Chain Forks](/img/dev/en-blockchain-fork.svg)
 
 Multiple blocks can all have the same block height, as is common when
 two or more miners each produce a block at roughly the same time. This
@@ -299,7 +299,7 @@ nodes. This creates permanently divergent chains---one for non-upgraded
 nodes and one for upgraded nodes---called a [hard
 fork][/en/glossary/hard-fork]{:#term-hard-fork}{:.term}.
 
-![Hard Fork](/img/dev/en-hard-fork.svg?{{site.time | date: '%s'}})
+![Hard Fork](/img/dev/en-hard-fork.svg)
 
 In the second case, rejection by upgraded nodes, it's possible to keep
 the block chain from permanently diverging if upgraded nodes control a
@@ -309,7 +309,7 @@ upgraded nodes can build a stronger chain that the non-upgraded nodes
 will accept as the best valid block chain. This is called a [soft
 fork][/en/glossary/soft-fork]{:#term-soft-fork}{:.term}.
 
-![Soft Fork](/img/dev/en-soft-fork.svg?{{site.time | date: '%s'}})
+![Soft Fork](/img/dev/en-soft-fork.svg)
 
 Although a fork is an actual divergence in block chains, changes to the
 consensus rules are often described by their potential to create either

--- a/_data/devdocs/en/guides/contracts.md
+++ b/_data/devdocs/en/guides/contracts.md
@@ -157,7 +157,7 @@ by locktime. This is the refund transaction. Bob can't sign the refund transacti
 it to Alice to sign, as shown in the
 illustration below.
 
-![Micropayment Channel Example](/img/dev/en-micropayment-channel.svg?{{site.time | date: '%s'}})
+![Micropayment Channel Example](/img/dev/en-micropayment-channel.svg)
 
 Alice checks that the refund transaction's locktime is 24 hours in the
 future, signs it, and gives a copy of it back to Bob. She then asks Bob
@@ -230,7 +230,7 @@ illustration below, makes this decision easy: they create a single
 transaction which does all of the spending simultaneously, ensuring none
 of them can steal the others' satoshis.
 
-![Example CoinJoin Transaction](/img/dev/en-coinjoin.svg?{{site.time | date: '%s'}})
+![Example CoinJoin Transaction](/img/dev/en-coinjoin.svg)
 
 Each contributor looks through their collection of Unspent Transaction
 Outputs (UTXOs) for 100 millibitcoins they can spend. They then each generate

--- a/_data/devdocs/en/guides/mining.md
+++ b/_data/devdocs/en/guides/mining.md
@@ -36,7 +36,7 @@ transactions from the network. Their mining software periodically polls
 provides the list of new transactions plus the public key to which the
 coinbase transaction should be sent.
 
-![Solo Bitcoin Mining](/img/dev/en-solo-mining-overview.svg?{{site.time | date: '%s'}})
+![Solo Bitcoin Mining](/img/dev/en-solo-mining-overview.svg)
 
 The mining software constructs a block using the template (described below) and creates a
 block header. It then sends the 80-byte block header to its mining
@@ -69,7 +69,7 @@ done. The mining pool gets new transactions from the network using
 software connects to the pool and requests the information it needs to
 construct block headers.
 
-![Pooled Bitcoin Mining](/img/dev/en-pooled-mining-overview.svg?{{site.time | date: '%s'}})
+![Pooled Bitcoin Mining](/img/dev/en-pooled-mining-overview.svg)
 
 In pooled mining, the mining pool sets the target threshold a few orders
 of magnitude higher (less difficult) than the network

--- a/_data/devdocs/en/guides/operating_modes.md
+++ b/_data/devdocs/en/guides/operating_modes.md
@@ -22,7 +22,7 @@ The first and most secure model is the one followed by Bitcoin Core, also known 
 
 For a client to be fooled, an adversary would need to give a complete alternative block chain history that is of greater difficulty than the current “true” chain, which is computationally expensive (if not impossible) due to the fact that the chain with the most cumulative proof of work is by definition the "true" chain. Due to the computational difficulty required to generate a new block at the tip of the chain, the ability to fool a full node becomes very expensive after 6 confirmations. This form of verification is highly resistent to sybil attacks---only a single honest network peer is required in order to receive and verify the complete state of the "true" block chain. 
 
-![Block Height Compared To Block Depth](/img/dev/en-block-height-vs-depth.svg?{{site.time | date: '%s'}})
+![Block Height Compared To Block Depth](/img/dev/en-block-height-vs-depth.svg)
 
 {% endautocrossref %}
 

--- a/_data/devdocs/en/guides/p2p_network.md
+++ b/_data/devdocs/en/guides/p2p_network.md
@@ -183,14 +183,14 @@ Bitcoin Core (up until version 0.9.3) uses a
 simple initial block download (IBD) method we'll call *blocks-first*.
 The goal is to download the blocks from the best block chain in sequence.
 
-![Overview Of Blocks-First Method](/img/dev/en-blocks-first-flowchart.svg?{{site.time | date: '%s'}})
+![Overview Of Blocks-First Method](/img/dev/en-blocks-first-flowchart.svg)
 
 The first time a node is started, it only has a single block in its
 local best block chain---the hardcoded genesis block (block 0).  This
 node chooses a remote peer, called the sync node, and sends it the
 `getblocks` message illustrated below.
 
-![First GetBlocks Message Sent During IBD](/img/dev/en-ibd-getblocks.svg?{{site.time | date: '%s'}})
+![First GetBlocks Message Sent During IBD](/img/dev/en-ibd-getblocks.svg)
 
 In the header hashes field of the `getblocks` message, this new node
 sends the header hash of the only block it has, the genesis block
@@ -204,7 +204,7 @@ replies with 500 block inventories (the maximum response to a
 `getblocks` message) starting from block 1. It sends these inventories
 in the `inv` message illustrated below.
 
-![First Inv Message Sent During IBD](/img/dev/en-ibd-inv.svg?{{site.time | date: '%s'}})
+![First Inv Message Sent During IBD](/img/dev/en-ibd-inv.svg)
 
 Inventories are unique identifiers for information on the network. Each
 inventory contains a type field and the unique identifier for an
@@ -219,7 +219,7 @@ is 4860...0000 as seen in the illustration above.)
 The IBD node uses the received inventories to request 128 blocks from
 the sync node in the `getdata` message illustrated below.
 
-![First GetData Message Sent During IBD](/img/dev/en-ibd-getdata.svg?{{site.time | date: '%s'}})
+![First GetData Message Sent During IBD](/img/dev/en-ibd-getdata.svg)
 
 It's important to blocks-first nodes that the blocks be requested and
 sent in order because each block header references the header hash of
@@ -233,7 +233,7 @@ of the blocks requested. Each block is put into serialized block format
 and sent in a separate `block` message. The first `block` message sent
 (for block 1) is illustrated below.
 
-![First Block Message Sent During IBD](/img/dev/en-ibd-block.svg?{{site.time | date: '%s'}})
+![First Block Message Sent During IBD](/img/dev/en-ibd-block.svg)
 
 The IBD node downloads each block, validates it, and then requests the
 next block it hasn't requested yet, maintaining a queue of up to 128
@@ -243,7 +243,7 @@ requesting the inventories of up to 500 more blocks.  This second
 `getblocks` message contains multiple header hashes as illustrated
 below:
 
-![Second GetBlocks Message Sent During IBD](/img/dev/en-ibd-getblocks2.svg?{{site.time | date: '%s'}})
+![Second GetBlocks Message Sent During IBD](/img/dev/en-ibd-getblocks2.svg)
 
 Upon receipt of the second `getblocks` message, the sync node searches
 its local best block chain for a block that matches one of the header
@@ -330,14 +330,14 @@ chain][/en/glossary/header-chain]{:#term-header-chain}{:.term}, partially valida
 as possible, and then download the corresponding blocks in parallel.  This
 solves several problems with the older blocks-first IBD method.
 
-![Overview Of Headers-First Method](/img/dev/en-headers-first-flowchart.svg?{{site.time | date: '%s'}})
+![Overview Of Headers-First Method](/img/dev/en-headers-first-flowchart.svg)
 
 The first time a node is started, it only has a single block in its
 local best block chain---the hardcoded genesis block (block 0).  The
 node chooses a remote peer, which we'll call the sync node, and sends it the
 `getheaders` message illustrated below.
 
-![First getheaders message](/img/dev/en-ibd-getheaders.svg?{{site.time | date: '%s'}})
+![First getheaders message](/img/dev/en-ibd-getheaders.svg)
 
 In the header hashes field of the `getheaders` message, the new node
 sends the header hash of the only block it has, the genesis block
@@ -351,7 +351,7 @@ replies with 2,000 header (the maximum response) starting from
 block 1. It sends these header hashes in the `headers` message
 illustrated below.
 
-![First headers message](/img/dev/en-ibd-headers.svg?{{site.time | date: '%s'}})
+![First headers message](/img/dev/en-ibd-headers.svg)
 
 The IBD node can partially validate these block headers by ensuring that
 all fields follow consensus rules and that the hash of the header is
@@ -399,7 +399,7 @@ two things in parallel:
     during IBD (the same maximum number that blocks-first Bitcoin Core
     requested from its sync node).
 
-![Simulated Headers-First Download Window](/img/dev/en-headers-first-moving-window.svg?{{site.time | date: '%s'}})
+![Simulated Headers-First Download Window](/img/dev/en-headers-first-moving-window.svg)
 
 Bitcoin Core's headers-first mode uses a 1,024-block moving download
 window to maximize download speed. The lowest-height block in the window
@@ -514,7 +514,7 @@ hasn't seen yet. In other words, orphan blocks have no known parent
 (unlike stale blocks, which have known parents but which aren't part of
 the best block chain).
 
-![Difference Between Orphan And Stale Blocks](/img/dev/en-orphan-stale-definition.svg?{{site.time | date: '%s'}})
+![Difference Between Orphan And Stale Blocks](/img/dev/en-orphan-stale-definition.svg)
 
 When a blocks-first node downloads an orphan block, it will not validate
 it. Instead, it will send a `getblocks` message to the node which sent

--- a/_data/devdocs/en/guides/payment_processing.md
+++ b/_data/devdocs/en/guides/payment_processing.md
@@ -17,7 +17,7 @@ can, respectively, request and make payments using Bitcoin---and how
 they can deal with complications such as refunds and recurrent
 rebilling.
 
-![Bitcoin Payment Processing](/img/dev/en-payment-processing.svg?{{site.time | date: '%s'}})
+![Bitcoin Payment Processing](/img/dev/en-payment-processing.svg)
 
 The figure above illustrates payment processing using Bitcoin from a
 receiver's perspective, starting with a new order. The following
@@ -121,7 +121,7 @@ payment requests is recommended.
    increased security, authentication of a receiver's identity using X.509 certificates,
    and other important features such as refunds.
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
  **Warning:** Special care must be taken to avoid the theft of incoming
 payments. In particular, private keys should not be stored on web servers,
 and payment requests should be sent over HTTPS or other secure methods
@@ -238,7 +238,7 @@ parameters---and any other optional parameters---but they were
 omitted here to keep the QR code small and easy to scan with unsteady
 or low-resolution mobile cameras.
 
-![Bitcoin QR Codes](/img/dev/en-qr-code.svg?{{site.time | date: '%s'}})
+![Bitcoin QR Codes](/img/dev/en-qr-code.svg)
 
 The error correction is combined with a checksum to ensure the Bitcoin QR code
 cannot be successfully decoded with data missing or accidentally altered,
@@ -294,7 +294,7 @@ the other parameters and fetch a PaymentRequest from the URL provided.
 The browser, QR code reader, or other program processing the URI opens
 the spender's Bitcoin wallet program on the URI. 
 
-![BIP70 Payment Protocol](/img/dev/en-payment-protocol.svg?{{site.time | date: '%s'}})
+![BIP70 Payment Protocol](/img/dev/en-payment-protocol.svg)
 
 The Payment Protocol is described in depth in BIP70, BIP71, and BIP72.
 An example CGI program and description of all the parameters which can
@@ -362,7 +362,7 @@ server's X.509 SSL certificate.  (The Payment Protocol has been designed
 to allow other signing methods in the future.)  Bob's server sends the
 payment request to Charlie's wallet in the reply to the HTTP GET.
 
-![Bitcoin Core Showing Validated Payment Request](/img/dev/en-btcc-payment-request.png?{{site.time | date: '%s'}})
+![Bitcoin Core Showing Validated Payment Request](/img/dev/en-btcc-payment-request.png)
 
 Charlie's wallet receives the PaymentRequest message, checks its signature, and
 then displays the details from the PaymentDetails message to Charlie. Charlie

--- a/_data/devdocs/en/guides/transactions.md
+++ b/_data/devdocs/en/guides/transactions.md
@@ -34,7 +34,7 @@ and they're an exception to many of the rules listed below. Instead of
 pointing out the coinbase exception to each rule, we invite you to read
 about coinbase transactions in the block chain section of this guide.
 
-![The Parts Of A Transaction](/img/dev/en-tx-overview.svg?{{site.time | date: '%s'}})
+![The Parts Of A Transaction](/img/dev/en-tx-overview.svg)
 
 The figure above shows the main parts of a Bitcoin transaction. Each
 transaction has at least one input and one output. Each [input][/en/glossary/input]{:#term-input}{:.term} spends the
@@ -48,7 +48,7 @@ Bitcoin peers and miners which set of rules to use to validate it.  This
 lets developers create new rules for future transactions without
 invalidating previous transactions.
 
-![Spending An Output](/img/dev/en-tx-overview-spending.svg?{{site.time | date: '%s'}})
+![Spending An Output](/img/dev/en-tx-overview-spending.svg)
 
 An output has an implied index number based on its location in the
 transaction---the index of the first output is zero. The output also has an
@@ -71,7 +71,7 @@ type. [P2PKH][/en/glossary/p2pkh-address]{:#term-p2pkh}{:.term} lets Alice spend
 and then lets Bob further spend those satoshis using a simple
 cryptographic key pair.
 
-![Creating A P2PKH Public Key Hash To Receive Payment](/img/dev/en-creating-p2pkh-output.svg?{{site.time | date: '%s'}})
+![Creating A P2PKH Public Key Hash To Receive Payment](/img/dev/en-creating-p2pkh-output.svg)
 
 Bob must first generate a private/public [key pair][]{:#term-key-pair}{:.term} before Alice can create the
 first transaction. Bitcoin uses the Elliptic Curve Digital Signature Algorithm (ECDSA) with
@@ -127,7 +127,7 @@ Pubkey scripts and signature scripts combine secp256k1 pubkeys
 and signatures with conditional logic, creating a programmable
 authorization mechanism.
 
-![Unlocking A P2PKH Output For Spending](/img/dev/en-unlocking-p2pkh-output.svg?{{site.time | date: '%s'}})
+![Unlocking A P2PKH Output For Spending](/img/dev/en-unlocking-p2pkh-output.svg)
 
 For a P2PKH-style output, Bob's signature script will contain the following two
 pieces of data:
@@ -144,7 +144,7 @@ Bob's secp256k1 signature doesn't just prove Bob controls his private key; it al
 makes the non-signature-script parts of his transaction tamper-proof so Bob can safely
 broadcast them over the peer-to-peer network.
 
-![Some Things Signed When Spending An Output](/img/dev/en-signing-output-to-spend.svg?{{site.time | date: '%s'}})
+![Some Things Signed When Spending An Output](/img/dev/en-signing-output-to-spend.svg)
 
 As illustrated in the figure above, the data Bob signs includes the
 txid and output index of the previous transaction, the previous
@@ -212,7 +212,7 @@ and continuing to the end of Alice's pubkey script. The figure below shows the
 evaluation of a standard P2PKH pubkey script; below the figure is a description
 of the process.
 
-![P2PKH Stack Evaluation](/img/dev/en-p2pkh-stack.svg?{{site.time | date: '%s'}})
+![P2PKH Stack Evaluation](/img/dev/en-p2pkh-stack.svg)
 
 * The signature (from Bob's signature script) is added (pushed) to an empty stack.
   Because it's just data, nothing is done except adding it to the stack.
@@ -281,7 +281,7 @@ wants, hashes the redeem script, and provides the redeem script
 hash to Alice. Alice creates a P2SH-style output containing
 Bob's redeem script hash.
 
-![Creating A P2SH Redeem Script And Hash](/img/dev/en-creating-p2sh-output.svg?{{site.time | date: '%s'}})
+![Creating A P2SH Redeem Script And Hash](/img/dev/en-creating-p2sh-output.svg)
 
 When Bob wants to spend the output, he provides his signature along with
 the full (serialized) redeem script in the signature script. The
@@ -290,7 +290,7 @@ value as the script hash Alice put in her output; it then processes the
 redeem script exactly as it would if it were the primary pubkey script, letting
 Bob spend the output if the redeem script does not return false.
 
-![Unlocking A P2SH Output For Spending](/img/dev/en-unlocking-p2sh-output.svg?{{site.time | date: '%s'}})
+![Unlocking A P2SH Output For Spending](/img/dev/en-unlocking-p2sh-output.svg)
 
 The hash of the redeem script has the same properties as a pubkey
 hash---so it can be transformed into the standard Bitcoin address format

--- a/_data/devdocs/en/guides/wallets.md
+++ b/_data/devdocs/en/guides/wallets.md
@@ -60,7 +60,7 @@ distribute those public keys as necessary, monitors for outputs spent to
 those public keys, creates and signs transactions spending those
 outputs, and broadcasts the signed transactions.
 
-![Full-Service Wallets](/img/dev/en-wallets-full-service.svg?{{site.time | date: '%s'}})
+![Full-Service Wallets](/img/dev/en-wallets-full-service.svg)
 
 As of this writing, almost all popular wallets can be used as
 full-service wallets.
@@ -97,7 +97,7 @@ Signing-only wallets programs typically use deterministic key creation
 (described in a later subsection) to create parent private and public
 keys which can create child private and public keys.
 
-![Signing-Only Wallets](/img/dev/en-wallets-signing-only.svg?{{site.time | date: '%s'}})
+![Signing-Only Wallets](/img/dev/en-wallets-signing-only.svg)
 
 When first run, the signing-only wallet creates a parent private key and
 transfers the corresponding parent public key to the networked wallet.
@@ -233,7 +233,7 @@ webservers, can be designed to distribute public keys (including P2PKH
 or P2SH addresses) and nothing more.  There are two common ways to
 design these minimalist wallets:
 
-![Distributing-Only Wallets](/img/dev/en-wallets-distributing-only.svg?{{site.time | date: '%s'}})
+![Distributing-Only Wallets](/img/dev/en-wallets-distributing-only.svg)
 
 * Pre-populate a database with a number of public keys or addresses, and
   then distribute on request a pubkey script or address using one of
@@ -346,7 +346,7 @@ shows such a point on the elliptic curve used by Bitcoin,
 y<sup>2</sup>&nbsp;=&nbsp;x<sup>3</sup>&nbsp;+&nbsp;7, over a field of
 contiguous numbers.
 
-![Point On ECDSA Curve](/img/dev/en-ecdsa-compressed-public-key.svg?{{site.time | date: '%s'}})
+![Point On ECDSA Curve](/img/dev/en-ecdsa-compressed-public-key.svg)
 
 (Secp256k1 actually modulos coordinates by a large prime, which produces a
 field of non-contiguous integers and a significantly less clear plot,
@@ -475,7 +475,7 @@ code][/en/glossary/master-chain-code-and-private-key]{:#term-master-chain-code}{
 even if, for example, a web-based public key distribution program
 gets hacked.
 
-![Overview Of Hierarchical Deterministic Key Derivation](/img/dev/en-hd-overview.svg?{{site.time | date: '%s'}})
+![Overview Of Hierarchical Deterministic Key Derivation](/img/dev/en-hd-overview.svg)
 
 As illustrated above, HD key derivation takes four inputs<!--noref-->:
 
@@ -519,7 +519,7 @@ key][/en/glossary/master-chain-code-and-private-key]{:#term-master-private-key}{
 code are derived from random data,
 as illustrated below.
 
-![Creating A Root Extended Key Pair](/img/dev/en-hd-root-keys.svg?{{site.time | date: '%s'}})
+![Creating A Root Extended Key Pair](/img/dev/en-hd-root-keys.svg)
 
 A [root seed][/en/glossary/hd-wallet-seed]{:#term-root-seed}{:.term} is created from either 128
 bits, 256 bits, or 512 bits of random data. This root seed of as little
@@ -527,7 +527,7 @@ as 128 bits is the the only data the user needs to backup in order to
 derive every key created by a particular wallet program using
 particular settings.
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
  **Warning:** As of this writing, HD wallet programs are not expected to
 be fully compatible, so users must only use the same HD wallet program
 with the same HD-related settings for a particular root seed.
@@ -556,7 +556,7 @@ further-descended private key, he can use the chain code to generate all
 of the extended private keys descending from that private key, as
 shown in the grandchild and great-grandchild generations of the illustration below.
 
-![Cross-Generational Key Compromise](/img/dev/en-hd-cross-generational-key-compromise.svg?{{site.time | date: '%s'}})
+![Cross-Generational Key Compromise](/img/dev/en-hd-cross-generational-key-compromise.svg)
 
 Perhaps worse, the attacker can reverse the normal child private key
 derivation formula and subtract a parent chain code from a child private
@@ -579,7 +579,7 @@ together the index number, the parent chain code, and the parent public key to c
 child chain code and the integer value which is combined with the parent
 private key to create the child private key.
 
-![Creating Child Public Keys From An Extended Private Key](/img/dev/en-hd-private-parent-to-private-child.svg?{{site.time | date: '%s'}})
+![Creating Child Public Keys From An Extended Private Key](/img/dev/en-hd-private-parent-to-private-child.svg)
 
 The hardened formula, illustrated above, combines together the index
 number, the parent chain code, and the parent private key to create
@@ -617,7 +617,7 @@ key and *M* being a public key. For example, m/0'/0/122' refers to the
 key. The following hierarchy illustrates prime notation and hardened key
 firewalls.
 
-![Example HD Wallet Tree Using Prime Notation](/img/dev/en-hd-tree.svg?{{site.time | date: '%s'}})
+![Example HD Wallet Tree Using Prime Notation](/img/dev/en-hd-tree.svg)
 
 Wallets following the BIP32 HD protocol only create hardened children of
 the master private key (*m*) to prevent a compromised child key from

--- a/_data/devdocs/en/references/block_chain.md
+++ b/_data/devdocs/en/references/block_chain.md
@@ -134,7 +134,7 @@ hashed to produce the merkle root.
 -->
 {% endcomment %}
 
-![Example Merkle Tree Construction](/img/dev/en-merkle-tree-construction.svg?{{site.time | date: '%s'}})
+![Example Merkle Tree Construction](/img/dev/en-merkle-tree-construction.svg)
 
 TXIDs and intermediate hashes are always in internal byte order when they're
 concatenated, and the resulting merkle root is also in internal byte
@@ -154,12 +154,12 @@ However, the header field *nBits* provides only 32 bits of space, so the
 target number uses a less precise format called "compact" which works
 like a base-256 version of scientific notation:
 
-![Converting nBits Into A Target Threshold](/img/dev/en-nbits-overview.svg?{{site.time | date: '%s'}})
+![Converting nBits Into A Target Threshold](/img/dev/en-nbits-overview.svg)
 
 As a base-256 number, nBits can be quickly parsed as bytes the same way
 you might parse a decimal number in base-10 scientific notation:
 
-![Quickly Converting nBits](/img/dev/en-nbits-quick-parse.svg?{{site.time | date: '%s'}})
+![Quickly Converting nBits](/img/dev/en-nbits-quick-parse.svg)
 
 {% comment %}
 <!-- Source for paragraph below: Bitcoin Core src/tests/bignum_tests.cpp:

--- a/_data/devdocs/en/references/p2p_networking.md
+++ b/_data/devdocs/en/references/p2p_networking.md
@@ -121,7 +121,7 @@ f9beb4d9 ................... Start string: Mainnet
 The following network messages all request or provide data related to
 transactions and blocks.
 
-![Overview Of P2P Protocol Data Request And Reply Messages](/img/dev/en-p2p-data-messages.svg?{{site.time | date: '%s'}})
+![Overview Of P2P Protocol Data Request And Reply Messages](/img/dev/en-p2p-data-messages.svg)
 
 Many of the data messages use
 [inventories][/en/glossary/inventory]{:#term-inventory}{:.term} as unique identifiers
@@ -824,7 +824,7 @@ The following network messages all help control the connection between
 two peers or allow them to advise each other about the rest of the
 network.
 
-![Overview Of P2P Protocol Control And Advisory Messages](/img/dev/en-p2p-control-messages.svg?{{site.time | date: '%s'}})
+![Overview Of P2P Protocol Control And Advisory Messages](/img/dev/en-p2p-control-messages.svg)
 
 Note that almost none of the control messages are authenticated in any
 way, meaning they can contain incorrect or intentionally harmful
@@ -1098,7 +1098,7 @@ it must be truncated to its four most significant bytes (for example,
 The actual hash function implementation used is the [32-bit Murmur3 hash
 function][murmur3].
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
 **Warning:** the Murmur3 hash function has separate 32-bit and 64-bit
 versions that produce different results for the same input.  Only the
 32-bit Murmur3 version is used with Bitcoin bloom filters.
@@ -1220,7 +1220,7 @@ address, or other data element matching the filter, the filtering node
 immediately updates the filter with the outpoint corresponding to that
 pubkey script.
 
-![Automatically Updating Bloom Filters](/img/dev/en-bloom-update.svg?{{site.time | date: '%s'}})
+![Automatically Updating Bloom Filters](/img/dev/en-bloom-update.svg)
 
 If an input later spends that outpoint, the filter will match it,
 allowing the filtering node to tell the client that one of its

--- a/_data/devdocs/en/references/transactions.md
+++ b/_data/devdocs/en/references/transactions.md
@@ -71,7 +71,7 @@ A complete list of opcodes can be found on the Bitcoin Wiki [Script
 Page][wiki script], with an authoritative list in the `opcodetype` enum
 of the Bitcoin Core [script header file][core script.h]
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
 **<span id="signature_script_modification_warning">Signature script modification warning</span>:**
 Signature scripts are not signed, so anyone can modify them. This
 means signature scripts should only contain data and data-pushing opcodes
@@ -81,7 +81,7 @@ makes a transaction non-standard, and future consensus rules may forbid
 such transactions altogether. (Non-data-pushing opcodes are already
 forbidden in signature scripts when spending a P2SH pubkey script.)
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
 **`OP_CHECKMULTISIG` warning:** The multisig verification process
 described above requires that signatures in the signature script be
 provided in the same order as their corresponding public keys in

--- a/_data/devdocs/en/references/wallets.md
+++ b/_data/devdocs/en/references/wallets.md
@@ -27,7 +27,7 @@ sharing is extremely limited.
 
 {% autocrossref %}
 
-![Overview Of Hierarchical Deterministic Key Derivation](/img/dev/en-hd-overview.svg?{{site.time | date: '%s'}})
+![Overview Of Hierarchical Deterministic Key Derivation](/img/dev/en-hd-overview.svg)
 
 For an overview of HD wallets, please see the [developer guide
 section][devguide wallets].  For details, please see BIP32.

--- a/_includes/helpers/hero-social.html
+++ b/_includes/helpers/hero-social.html
@@ -5,9 +5,9 @@ http://opensource.org/licenses/MIT.
 
 <div class="row hero-social">
   <a href="" onclick="window.open('http://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(location.href))" class="hero-social-link" target="_blank">
-    <img src="/img/icons/ico_facebook_bright.svg?{{site.time | date: '%s'}}" alt="facebook">
+    <img src="/img/icons/ico_facebook_bright.svg" alt="facebook">
   </a>
   <a href="" onclick="window.open('https://twitter.com/share?url=' + encodeURIComponent(location.href))" class="hero-social-link" target="_blank">
-    <img src="/img/icons/ico_twitter_bright.svg?{{site.time | date: '%s'}}" alt="twitter">
+    <img src="/img/icons/ico_twitter_bright.svg" alt="twitter">
   </a>
 </div>

--- a/_includes/helpers/vars.md
+++ b/_includes/helpers/vars.md
@@ -119,7 +119,7 @@ http://opensource.org/licenses/MIT.
 
 {% enditemplate %}
 
-![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+![Warning icon](/img/icons/icon_warning.svg)
 **Warning:** if account1 receives an unconfirmed payment and transfers
 it to account2 with the `move` RPC, account2 will be able to spend those
 bitcoins even if this parameter is set to `1` or higher.{% endcapture %}
@@ -285,6 +285,6 @@ bitcoins even if this parameter is set to `1` or higher.{% endcapture %}
 {% enditemplate %}
 {% endcapture %}
 
-{% assign WARNING="![Warning icon](/img/icons/icon_warning.svg?1528322191) **Warning:**" %}
+{% assign WARNING="![Warning icon](/img/icons/icon_warning.svg) **Warning:**" %}
 
 {% assign reindexNote="Note: if you begin using `txindex=1` after downloading the block chain, you must rebuild your indexes by starting Bitcoin Core with the option  `-reindex`.  This may take several hours to complete, during which time your node will not process new blocks or transactions. This reindex only needs to be done once." %}

--- a/_includes/layout/base/footer-logo.html
+++ b/_includes/layout/base/footer-logo.html
@@ -4,5 +4,5 @@ http://opensource.org/licenses/MIT.
 {% endcomment %}
 
 <a class="logo-footer" href="/{{ page.lang }}/">
-  <img src="/img/icons/logo-footer.svg?{{site.time | date: '%s'}}" alt="Bitcoin">
+  <img src="/img/icons/logo-footer.svg" alt="Bitcoin">
 </a>

--- a/_includes/layout/base/footer-sponsor.html
+++ b/_includes/layout/base/footer-sponsor.html
@@ -4,5 +4,5 @@ http://opensource.org/licenses/MIT.
 {% endcomment %}
 
 <div class="footersponsor">
-  <!--<div><span>{% translate sponsor layout %}</span> <a href="https://bitcoinfoundation.org/"><img src="/img/brand/bitcoinfoundation.png?{{site.time | date: '%s'}}" alt="Bitcoin Foundation"></a></div>-->
+  <!--<div><span>{% translate sponsor layout %}</span> <a href="https://bitcoinfoundation.org/"><img src="/img/brand/bitcoinfoundation.png" alt="Bitcoin Foundation"></a></div>-->
 </div>

--- a/_includes/layout/base/html-head.html
+++ b/_includes/layout/base/html-head.html
@@ -4,12 +4,12 @@ http://opensource.org/licenses/MIT.
 {% endcomment %}
 
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-<meta property="og:image" content="{{site.url}}/img/icons/opengraph.png?{{site.time | date: '%s'}}" />
+<meta property="og:image" content="{{site.url}}/img/icons/opengraph.png" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>{% capture title %}{% translate title %}{% endcapture %}{% if title != '' %}{{ title }}{% else %}{{ page.title }}{% endif %}</title>
 {% capture metadescription %}{% translate metadescription %}{% endcapture %}{% if metadescription != '' %}<meta name="description" content="{{ metadescription }}">{% endif %}
 <link rel="stylesheet" href="/css/font-awesome-4.4.0/css/font-awesome.min.css">
-<link rel="stylesheet" href="/css/main.css?{{site.time | date: '%s'}}">
+<link rel="stylesheet" href="/css/main.css">
 <!--[if lt IE 8]><link rel="stylesheet" href="/css/ie.css"><script type="text/javascript" src="/js/ie.js"></script><![endif]-->
 <!--[if IE 8]><link rel="stylesheet" href="/css/ie8.css"><![endif]-->
 {% if page.lang == 'ar' or page.lang == 'fa' %}<link rel="stylesheet" href="/css/rtl.css">{% endif %}

--- a/_includes/layout/base/wallets-filter.html
+++ b/_includes/layout/base/wallets-filter.html
@@ -66,7 +66,7 @@ http://opensource.org/licenses/MIT.
     {% endfor %}
     <div class="wallet-list-item allwallets-list-item" data-platforms="{{platformList}}" data-category="all-wallets" data-walletlevel="{{ wallet.level }}">
         <div class="wallet-list-item-link">
-          <img src="/img/wallet/{{ wallet.id }}.png?{{site.time | date: '%s'}}" alt="{{ wallet.title }}" /> {{ wallet.titleshort }}
+          <img src="/img/wallet/{{ wallet.id }}.png" alt="{{ wallet.title }}" /> {{ wallet.titleshort }}
         </div>
         <p class="wallet-hint">Select an Operating System</p>
         <div class="wallet-list-os">
@@ -103,7 +103,7 @@ http://opensource.org/licenses/MIT.
             {% else %}
             <a class="wallet-list-item-link" href="/{{ page.lang}}/wallets/{{ platform.name }}/{{ os.name }}/{{ wallet.id }}/">
             {% endif %}
-            <img src="/img/wallet/{{ wallet.id }}.png?{{site.time | date: '%s'}}" alt="{{ wallet.title }}" /> {{ wallet.titleshort }}
+            <img src="/img/wallet/{{ wallet.id }}.png" alt="{{ wallet.title }}" /> {{ wallet.titleshort }}
             </a>
           </div>
           {% endfor %}

--- a/_layouts/about-sidebar.html
+++ b/_layouts/about-sidebar.html
@@ -29,9 +29,9 @@ end_of_page: |
         <div class="own-timeline">
           <p class="own-timeline-text">Beginning</p>
           <div class="own-timeline-number">
-            <img src="../img/getting-started/number-1.svg?{{site.time | date: '%s'}}" alt="1" class="own-timeline-number-img">
+            <img src="../img/getting-started/number-1.svg" alt="1" class="own-timeline-number-img">
           </div>
-          <img src="../img/icons/begining.svg?{{site.time | date: '%s'}}" alt="icon" class="own-timeline-icon">
+          <img src="../img/icons/begining.svg" alt="icon" class="own-timeline-icon">
         </div>
         <div class="own-text">
           <h3 id="owntxt-title">{% translate owntxt-title %}</h3>
@@ -43,9 +43,9 @@ end_of_page: |
         <div class="own-timeline">
           <p class="own-timeline-text">2011-2012</p>
           <div class="own-timeline-number">
-            <img src="../img/getting-started/number-2.svg?{{site.time | date: '%s'}}" alt="2" class="own-timeline-number-img">
+            <img src="../img/getting-started/number-2.svg" alt="2" class="own-timeline-number-img">
           </div>
-          <img src="../img/icons/bitcoincore.svg?{{site.time | date: '%s'}}" alt="icon" class="own-timeline-icon">
+          <img src="../img/icons/bitcoincore.svg" alt="icon" class="own-timeline-icon">
         </div>
         <div class="own-text">
           <h3 id="owntxt2-title">{% translate owntxt2-title %}</h3>
@@ -57,9 +57,9 @@ end_of_page: |
         <div class="own-timeline">
           <p class="own-timeline-text">2014</p>
           <div class="own-timeline-number">
-            <img src="../img/getting-started/number-3.svg?{{site.time | date: '%s'}}" alt="3" class="own-timeline-number-img">
+            <img src="../img/getting-started/number-3.svg" alt="3" class="own-timeline-number-img">
           </div>
-          <img src="../img/icons/ico_documentation.svg?{{site.time | date: '%s'}}" alt="icon" class="own-timeline-icon">
+          <img src="../img/icons/ico_documentation.svg" alt="icon" class="own-timeline-icon">
         </div>
         <div class="own-text">
           <h3 id="owntxt3-title">{% translate owntxt3-title %}</h3>
@@ -71,9 +71,9 @@ end_of_page: |
         <div class="own-timeline">
           <p class="own-timeline-text">Today</p>
           <div class="own-timeline-number own-timeline-number-4">
-            <img src="../img/getting-started/number-4.svg?{{site.time | date: '%s'}}" alt="4" class="own-timeline-number-img">
+            <img src="../img/getting-started/number-4.svg" alt="4" class="own-timeline-number-img">
           </div>
-          <img src="../img/icons/open-source.svg?{{site.time | date: '%s'}}" alt="icon" class="own-timeline-icon">
+          <img src="../img/icons/open-source.svg" alt="icon" class="own-timeline-icon">
         </div>
         <div class="own-text">
           <h3 id="owntxt4-title">{% translate owntxt4-title %}</h3>

--- a/_plugins/sitemap.rb
+++ b/_plugins/sitemap.rb
@@ -45,13 +45,23 @@ module Jekyll
         sitemap.puts '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
         sitemap.puts '	xmlns:xhtml="http://www.w3.org/1999/xhtml">'
         #Add translated pages with their alternative in each languages
+        ids = []
         locs['en']['url'].each do |id,value|
-          locs.each do |lang,value|
+          ids.push(id)
+        end
+        langs = []
+        locs.each do |lang,value|
+          langs.push(lang)
+        end
+        ids.sort!
+        langs.sort!
+        ids.each do |id|
+          langs.each do |lang|
             #Don't add a page if their url is not translated
             next if locs[lang]['url'][id].nil? or locs[lang]['url'][id] == ''
             sitemap.puts '<url>'
             sitemap.puts '  <loc>' + site.config["url"] + '/'+lang+'/'+CGI::escape(locs[lang]['url'][id])+'</loc>'
-            locs.each do |altlang,value|
+            langs.each do |altlang|
               next if locs[altlang]['url'][id].nil? or locs[altlang]['url'][id] == '' or altlang == lang
               sitemap.puts '  <xhtml:link'
               sitemap.puts '    rel="alternate"'
@@ -62,7 +72,12 @@ module Jekyll
           end
         end
 	#Add static non-translated pages
+        files = []
         Dir.glob('en/**/*.{md,html}').concat(Dir.glob('*.{md,html}')).each do |file|
+          files.push(file)
+        end
+        files.sort!
+        files.each do |file|
           next if file == 'index.html' or file == '404.html' or file == 'README.md'
           #Ignore google webmaster tools
           data = File.read(file)
@@ -72,7 +87,12 @@ module Jekyll
           sitemap.puts '</url>'
         end
         #Add alerts pages
+        alerts = []
         Dir.foreach('_alerts') do |file|
+          alerts.push(file)
+        end
+        alerts.sort!
+        alerts.each do |file|
           next if file == '.' or file == '..'
           sitemap.puts '<url>'
           sitemap.puts '  <loc>' + site.config["url"] + '/'+file.gsub('.html','')+'</loc>'

--- a/_wallets/airbitzwallet.md
+++ b/_wallets/airbitzwallet.md
@@ -15,7 +15,7 @@ platform:
         text: "walletairbitzwallet"
         link: "https://play.google.com/store/apps/details?id=com.airbitz"
         source: "https://github.com/Airbitz"
-        screenshot: "airbitzwalletandroid.png?1528322191"
+        screenshot: "airbitzwalletandroid.png"
         check:
           control: "checkpasscontrolhybrid"
           validation: "checkpassvalidationservers"
@@ -31,7 +31,7 @@ platform:
         text: "walletairbitzwallet"
         link: "https://itunes.apple.com/us/app/bitcoin-wallet-map-directory/id843536046?mt=8"
         source: "https://github.com/Airbitz"
-        screenshot: "airbitzwalletios.png?1528322191"
+        screenshot: "airbitzwalletios.png"
         check:
           control: "checkpasscontrolhybrid"
           validation: "checkpassvalidationservers"

--- a/_wallets/arcbit.md
+++ b/_wallets/arcbit.md
@@ -14,7 +14,7 @@ platform:
       text: "walletarcbit"
       link: "https://chrome.google.com/webstore/detail/arcbit-bitcoin-wallet/dkceiphcnbfahjbomhpdgjmphnpgogfk"
       source: "https://github.com/arcbit/arcbit-web"
-      screenshot: "arcbitdesktop.png?1528322191"
+      screenshot: "arcbitdesktop.png"
       check:
         control: "checkgoodcontrolfull"
         validation: "checkfailvalidationcentralized"
@@ -40,7 +40,7 @@ platform:
         text: "walletarcbit"
         link: "https://itunes.apple.com/app/arcbit-bitcoin-wallet/id999487888"
         source: "https://github.com/arcbit/arcbit-ios"
-        screenshot: "arcbitios.png?1528322191"
+        screenshot: "arcbitios.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"
@@ -56,7 +56,7 @@ platform:
         text: "walletarcbit"
         link: "https://play.google.com/store/apps/details?id=com.arcbit.arcbit"
         source: "https://github.com/arcbit/arcbit-android"
-        screenshot: "arcbitios.png?1528322191"
+        screenshot: "arcbitios.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"

--- a/_wallets/armory.md
+++ b/_wallets/armory.md
@@ -14,7 +14,7 @@ platform:
       text: "walletarmory"
       link: "https://btcarmory.com/"
       source: "https://github.com/goatpig/BitcoinArmory"
-      screenshot: "armory.png?1528322191"
+      screenshot: "armory.png"
       check:
         control: "checkgoodcontrolfull"
         validation: "checkgoodvalidationfullnoderequired"

--- a/_wallets/bitcoincore.md
+++ b/_wallets/bitcoincore.md
@@ -14,7 +14,7 @@ platform:
       text: "walletbitcoincore"
       link: "https://bitcoincore.org/en/download"
       source: "https://github.com/bitcoin/bitcoin"
-      screenshot: "bitcoincore.png?1528322191"
+      screenshot: "bitcoincore.png"
       check:
         control: "checkgoodcontrolfull"
         validation: "checkgoodvalidationfullnode"

--- a/_wallets/bitcoinknots.md
+++ b/_wallets/bitcoinknots.md
@@ -14,7 +14,7 @@ platform:
       text: "walletbitcoinknots"
       link: "https://bitcoinknots.org/"
       source: "https://github.com/bitcoinknots/bitcoin/"
-      screenshot: "bitcoinknots.png?1528322191"
+      screenshot: "bitcoinknots.png"
       check:
         control: "checkgoodcontrolfull"
         validation: "checkgoodvalidationfullnode"

--- a/_wallets/bitcoinwallet.md
+++ b/_wallets/bitcoinwallet.md
@@ -15,7 +15,7 @@ platform:
         text: "walletbitcoinwallet"
         link: "https://play.google.com/store/apps/details?id=de.schildbach.wallet"
         source: "https://github.com/bitcoin-wallet/bitcoin-wallet"
-        screenshot: "bitcoinwalletandroid.png?1528322191"
+        screenshot: "bitcoinwalletandroid.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkpassvalidationspvp2p"

--- a/_wallets/bitgo.md
+++ b/_wallets/bitgo.md
@@ -14,7 +14,7 @@ platform:
       - name: web
         text: "walletbitgo"
         link: "https://www.bitgo.com/"
-        screenshot: "bitgo.png?1528322191"
+        screenshot: "bitgo.png"
         check:
           control: "checkpasscontrolmulti"
           validation: "checkfailvalidationcentralized"

--- a/_wallets/bither.md
+++ b/_wallets/bither.md
@@ -15,7 +15,7 @@ platform:
         text: "walletbither"
         link: "https://itunes.apple.com/us/app/bither/id899478936"
         source: "https://github.com/bither/bither-ios"
-        screenshot: "bithermobile.png?1528322191"
+        screenshot: "bithermobile.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkpassvalidationspvp2p"
@@ -31,7 +31,7 @@ platform:
         text: "walletbither"
         link: "https://play.google.com/store/apps/details?id=net.bither"
         source: "https://github.com/bither/bither-android"
-        screenshot: "bithermobile.png?1528322191"
+        screenshot: "bithermobile.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkpassvalidationspvp2p"
@@ -49,7 +49,7 @@ platform:
       text: "walletbither"
       link: "https://bither.net"
       source: "https://github.com/bither/bither-desktop-java"
-      screenshot: "bitherdesktop.png?1528322191"
+      screenshot: "bitherdesktop.png"
       check:
         control: "checkgoodcontrolfull"
         validation: "checkpassvalidationspvp2p"

--- a/_wallets/brd.md
+++ b/_wallets/brd.md
@@ -15,7 +15,7 @@ platform:
         text: "walletbrd"
         link: "https://itunes.apple.com/app/brd-bitcoin-wallet/id885251393"
         source: "https://github.com/breadwallet/breadwallet-ios"
-        screenshot: "brd.png?1528322191"
+        screenshot: "brd.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkpassvalidationspvp2p"
@@ -31,7 +31,7 @@ platform:
         text: "walletbrd"
         link: "https://play.google.com/store/apps/details?id=com.breadwallet"
         source: "https://github.com/breadwallet/breadwallet-android"
-        screenshot: "brd.png?1528322191"
+        screenshot: "brd.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkpassvalidationspvp2p"

--- a/_wallets/coinspace.md
+++ b/_wallets/coinspace.md
@@ -15,7 +15,7 @@ platform:
         text: "walletcoinspace"
         link: "https://play.google.com/store/apps/details?id=com.coinspace.app"
         source: "https://github.com/CoinSpace/CoinSpace"
-        screenshot: "coinspacemobile.png?1528322191"
+        screenshot: "coinspacemobile.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"
@@ -31,7 +31,7 @@ platform:
         text: "walletcoinspace"
         link: "https://itunes.apple.com/us/app/coinspace-bitcoin-wallet/id980719434?mt=8"
         source: "https://github.com/CoinSpace/CoinSpace"
-        screenshot: "coinspacemobile.png?1528322191"
+        screenshot: "coinspacemobile.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"
@@ -47,7 +47,7 @@ platform:
         text: "walletcoinspace"
         link: "https://www.microsoft.com/en-us/store/apps/coin-space-digital-currency-wallet/9nblgggz58z9"
         source: "https://github.com/CoinSpace/CoinSpace"
-        screenshot: "coinspacemobile.png?1528322191"
+        screenshot: "coinspacemobile.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"
@@ -66,7 +66,7 @@ platform:
         text: "walletcoinspace"
         link: "https://coin.space"
         source: "https://github.com/CoinSpace/CoinSpace"
-        screenshot: "coinspaceweb.png?1528322191"
+        screenshot: "coinspaceweb.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"

--- a/_wallets/digitalbitbox.md
+++ b/_wallets/digitalbitbox.md
@@ -15,7 +15,7 @@ platform:
         text: "walletdbb"
         link: "https://digitalbitbox.com/"
         source: "https://github.com/digitalbitbox/"
-        screenshot: "digitalbitbox.png?1528322191"
+        screenshot: "digitalbitbox.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkneutralvalidationvariable"

--- a/_wallets/electrum.md
+++ b/_wallets/electrum.md
@@ -14,7 +14,7 @@ platform:
       text: "walletelectrum"
       link: "https://electrum.org"
       source: "https://github.com/spesmilo/electrum"
-      screenshot: "electrum.png?1528322191"
+      screenshot: "electrum.png"
       check:
         control: "checkgoodcontrolfull"
         validation: "checkpassvalidationspvservers"
@@ -40,7 +40,7 @@ platform:
         text: "walletelectrum"
         link: "https://play.google.com/store/apps/details?id=org.electrum.electrum"
         source: "https://github.com/spesmilo/electrum"
-        screenshot: "electrumandroid.png?1528322191"
+        screenshot: "electrumandroid.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkpassvalidationspvservers"

--- a/_wallets/greenaddress.md
+++ b/_wallets/greenaddress.md
@@ -15,7 +15,7 @@ platform:
         text: "walletgreenaddress"
         link: "https://itunes.apple.com/app/id1206035886"
         source: "https://github.com/greenaddress/WalletCordova"
-        screenshot: "greenaddressandroid.png?1528322191"
+        screenshot: "greenaddressandroid.png"
         check:
           control: "checkpasscontrolmulti"
           validation: "checkpassvalidationservers"
@@ -31,7 +31,7 @@ platform:
         text: "walletgreenaddress"
         link: "https://play.google.com/store/apps/details?id=it.greenaddress.cordova"
         source: "https://github.com/greenaddress/WalletCordova"
-        screenshot: "greenaddressandroid.png?1528322191"
+        screenshot: "greenaddressandroid.png"
         check:
           control: "checkpasscontrolmulti"
           validation: "checkpassvalidationservers"
@@ -49,7 +49,7 @@ platform:
       text: "walletgreenaddress"
       link: "https://github.com/greenaddress/WalletElectron/releases"
       source: "https://github.com/greenaddress/WalletElectron"
-      screenshot: "greenaddressdesktop.png?1528322191"
+      screenshot: "greenaddressdesktop.png"
       check:
         control: "checkpasscontrolmulti"
         validation: "checkfailvalidationcentralized"

--- a/_wallets/greenbits.md
+++ b/_wallets/greenbits.md
@@ -15,7 +15,7 @@ platform:
         text: "walletgreenbits"
         link: "https://play.google.com/store/apps/details?id=com.greenaddress.greenbits_android_wallet"
         source: "https://github.com/greenaddress/GreenBits"
-        screenshot: "greenbits.png?1528322191"
+        screenshot: "greenbits.png"
         check:
           control: "checkpasscontrolmulti"
           validation: "checkpassvalidationspvp2p"

--- a/_wallets/keepkey.md
+++ b/_wallets/keepkey.md
@@ -15,7 +15,7 @@ platform:
         text: "walletkeepkey"
         link: "https://www.keepkey.com/"
         source: "https://github.com/keepkey/"
-        screenshot: "keepkey.png?1528322191"
+        screenshot: "keepkey.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkneutralvalidationvariable"

--- a/_wallets/ledgernanos.md
+++ b/_wallets/ledgernanos.md
@@ -15,7 +15,7 @@ platform:
         text: "walletnanos"
         link: "https://www.ledgerwallet.com/"
         source: "https://github.com/LedgerHQ/"
-        screenshot: "ledgernanos.png?1528322191"
+        screenshot: "ledgernanos.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkneutralvalidationvariable"

--- a/_wallets/msigna.md
+++ b/_wallets/msigna.md
@@ -14,7 +14,7 @@ platform:
       text: "walletmsigna"
       link: "https://ciphrex.com/"
       source: "https://github.com/ciphrex/CoinVault"
-      screenshot: "msigna.png?1528322191"
+      screenshot: "msigna.png"
       check:
         control: "checkgoodcontrolfull"
         validation: "checkgoodvalidationfullnoderequired"

--- a/_wallets/mycelium.md
+++ b/_wallets/mycelium.md
@@ -15,7 +15,7 @@ platform:
         text: "walletmyceliumwallet"
         link: "https://play.google.com/store/apps/details?id=com.mycelium.wallet"
         source: "https://github.com/mycelium-com/wallet"
-        screenshot: "mycelium.png?1528322191"
+        screenshot: "mycelium.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"

--- a/_wallets/simplebitcoinwallet.md
+++ b/_wallets/simplebitcoinwallet.md
@@ -15,7 +15,7 @@ platform:
         text: "walletsimplebitcoinwallet"
         link: "https://play.google.com/store/apps/details?id=com.btcontract.wallet"
         source: "https://github.com/btcontract/wallet"
-        screenshot: "simplebitcoinwalletandroid.png?1528322191"
+        screenshot: "simplebitcoinwalletandroid.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkpassvalidationspvp2p"

--- a/_wallets/trezor.md
+++ b/_wallets/trezor.md
@@ -15,7 +15,7 @@ platform:
         text: "wallettrezor"
         link: "https://trezor.io/"
         source: "https://github.com/trezor/"
-        screenshot: "trezor.png?1528322191"
+        screenshot: "trezor.png"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkneutralvalidationvariable"

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -233,7 +233,7 @@ So your wallet may not count new payments/spendings into the balance.
 
 If you are using Bitcoin Core GUI, you can monitor the progress of IBD in the status bar(left bottom corner).
 
-![Bitcoin-Qt Initial Block Download](/img/full-node/en-bitcoin-qt-ibd.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Initial Block Download](/img/full-node/en-bitcoin-qt-ibd.png)
 
 ## Linux Instructions
 
@@ -247,7 +247,7 @@ systems.
 If you use Ubuntu Desktop, click the Ubuntu swirl icon to start the Dash and type "term" into the
 input box. Choose any one of the terminals listed:
 
-![Dash term](/img/full-node/en-dash-term.png?{{site.time | date: '%s'}})
+![Dash term](/img/full-node/en-dash-term.png)
 
 Alternatively, access a console or terminal emulator using another
 method, such as SSH on Ubuntu Server or a terminal launcher in an
@@ -325,13 +325,13 @@ want to proceed.  Press enter to continue.
 To start Bitcoin Core GUI, click the Ubuntu swirl icon to open the Dash,
 type `bitcoin`, and click the Bitcoin icon.
 
-![Dash Bitcoin-Qt](/img/full-node/en-dash-bitcoin-qt.png?{{site.time | date: '%s'}})
+![Dash Bitcoin-Qt](/img/full-node/en-dash-bitcoin-qt.png)
 
 You will be prompted to choose a directory to store the Bitcoin block
 chain and your wallet.  Unless you have a separate partition or drive
 you want to use, click Ok to use the default.
 
-![Bitcoin-Qt Welcome](/img/full-node/en-bitcoin-qt-welcome.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Welcome](/img/full-node/en-bitcoin-qt-welcome.png)
 
 Bitcoin Core GUI will begin to download the block chain.  This
 step will take at least several days, and it may take much more time on
@@ -340,7 +340,7 @@ download, Bitcoin Core will use a significant part of your connection
 bandwidth.  You can stop Bitcoin Core at any time by closing it; it will
 resume from the point where it stopped the next time you start it.
 
-![Bitcoin-Qt Initial Block Download](/img/full-node/en-bitcoin-qt-ibd.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Initial Block Download](/img/full-node/en-bitcoin-qt-ibd.png)
 
 After download is complete, you may use Bitcoin Core as your wallet or
 you can just let it run to help support the Bitcoin network.
@@ -356,12 +356,12 @@ While running Bitcoin Core GUI, open the Settings menu and choose
 Options.  On the Main tab, click *Start Bitcoin on system login*.  Click
 the Ok button to save the new settings.
 
-![Choosing to start Bitcoin Core at login](/img/full-node/en-start-on-login.png?{{site.time | date: '%s'}})
+![Choosing to start Bitcoin Core at login](/img/full-node/en-start-on-login.png)
 
 The next time you login to your desktop, Bitcoin Core GUI will be
 automatically started in as an icon in the tray.
 
-![Bitcoin-Qt Tray Icon](/img/full-node/en-bitcoin-qt-tray-icon.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Tray Icon](/img/full-node/en-bitcoin-qt-tray-icon.png)
 </div>
 
 {{installFinished}}
@@ -425,7 +425,7 @@ Bourne-like shell such as `bash`.
 Using any computer, go to the [Bitcoin Core download page][]
 and verify you have made a secure connection to the server.
 
-![Verify secure connection](/img/full-node/en-secure-connection.png?{{site.time | date: '%s'}})
+![Verify secure connection](/img/full-node/en-secure-connection.png)
 
 In the "Linux (tgz)" section of the Download page, choose the
 appropriate file for your Linux install (either 32-bit or 64-bit) and
@@ -508,7 +508,7 @@ You will be prompted to choose a directory to store the Bitcoin block
 chain and your wallet.  Unless you have a separate partition or drive
 you want to use, click *Ok* to use the default.
 
-![Bitcoin-Qt Welcome](/img/full-node/en-bitcoin-qt-welcome.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Welcome](/img/full-node/en-bitcoin-qt-welcome.png)
 
 Bitcoin Core GUI will begin to download the block chain.  This step will take at
 least several days, and it may take much more time on a slow Internet connection
@@ -517,7 +517,7 @@ significant part of your connection bandwidth.  You can stop Bitcoin Core at any
 time by closing it; it will resume from the point where it stopped the next time
 you start it.
 
-![Bitcoin-Qt Initial Block Download](/img/full-node/en-bitcoin-qt-ibd.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Initial Block Download](/img/full-node/en-bitcoin-qt-ibd.png)
 
 After download is complete, you may use Bitcoin Core as your wallet or
 you can just let it run to help support the Bitcoin network.
@@ -536,12 +536,12 @@ While running Bitcoin Core GUI, open the Settings menu and choose
 Options.  On the Main tab, click *Start Bitcoin on system login*.  Click
 the Ok button to save the new settings.
 
-![Choosing to start Bitcoin Core at login](/img/full-node/en-start-on-login.png?{{site.time | date: '%s'}})
+![Choosing to start Bitcoin Core at login](/img/full-node/en-start-on-login.png)
 
 The next time you login to your desktop, Bitcoin Core GUI should be
 automatically started in as an icon in the tray.
 
-![Bitcoin-Qt Tray Icon](/img/full-node/en-bitcoin-qt-tray-icon.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Tray Icon](/img/full-node/en-bitcoin-qt-tray-icon.png)
 
 If Bitcoin Core GUI does not automatically start, you may need to add it
 to an `.xinit` or `.xsession` file as [described
@@ -610,7 +610,7 @@ If you're a expert system administrator and want to use an init script instead, 
 Go to the [Bitcoin Core download page][] and verify you have
 made a secure connection to the server.
 
-![Verify secure connection](/img/full-node/en-win10-secure-connection.png?{{site.time | date: '%s'}})
+![Verify secure connection](/img/full-node/en-win10-secure-connection.png)
 
 Click the large blue *Download Bitcoin Core* button to download the
 Bitcoin Core installer to your desktop.
@@ -624,7 +624,7 @@ Bitcoin installer will start.  It's a typical Windows installer, and it will
 guide you through the decisions you need to make about where to install Bitcoin
 Core.
 
-![Windows 10 installer start](/img/full-node/en-win10-installer-start.png?{{site.time | date: '%s'}})
+![Windows 10 installer start](/img/full-node/en-win10-installer-start.png)
 
 <div class="box" markdown="1">
 *To continue, choose one of the following options*
@@ -650,20 +650,20 @@ Core.
 Press the Windows key (`⊞ Win`) and start typing "bitcoin".  When the
 Bitcoin Core icon appears (as shown below), click on it.
 
-![Starting Bitcoin Core](/img/full-node/en-win10-start-bitcoin-core.png?{{site.time | date: '%s'}})
+![Starting Bitcoin Core](/img/full-node/en-win10-start-bitcoin-core.png)
 
 You will be prompted to choose a directory to store the Bitcoin block
 chain and your wallet.  Unless you have a separate partition or drive
 you want to use, click Ok to use the default.
 
-![Bitcoin-Qt Welcome](/img/full-node/en-win10-welcome-to-bitcoin-core.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Welcome](/img/full-node/en-win10-welcome-to-bitcoin-core.png)
 
 Your firewall may block Bitcoin Core from making outbound connections.
 It's safe to allow Bitcoin Core to use all networks. (Note: you will
 still need to configure inbound connections as described later in the
 [Network Configuration](#network-configuration) section.)
 
-![Opening outgoing firewall for Bitcoin Core](/img/full-node/en-win10-bitcoin-core-outgoing-firewall.png?{{site.time | date: '%s'}})
+![Opening outgoing firewall for Bitcoin Core](/img/full-node/en-win10-bitcoin-core-outgoing-firewall.png)
 
 Bitcoin Core GUI will begin to download the block chain.  This step will take at
 least several days, and it may take much more time on a slow Internet connection
@@ -672,7 +672,7 @@ significant part of your connection bandwidth.  You can stop Bitcoin Core at any
 time by closing it; it will resume from the point where it stopped the next time
 you start it.
 
-![Bitcoin-Qt Initial Block Download](/img/full-node/en-win10-ibd.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Initial Block Download](/img/full-node/en-win10-ibd.png)
 
 After download is complete, you may use Bitcoin Core as your wallet or
 you can just let it run to help support the Bitcoin network.
@@ -688,7 +688,7 @@ While running Bitcoin Core GUI, open the Settings menu and choose
 Options.  On the Main tab, click *Start Bitcoin on system login*.  Click
 the Ok button to save the new settings.
 
-![Choosing to start Bitcoin Core at login](/img/full-node/en-win10-start-on-login.png?{{site.time | date: '%s'}})
+![Choosing to start Bitcoin Core at login](/img/full-node/en-win10-start-on-login.png)
 
 The next time you login to your desktop, Bitcoin Core GUI will be
 automatically started minimized in the task bar.
@@ -706,7 +706,7 @@ To start Bitcoin Core daemon, first open a command window: press the
 Windows key (`⊞ Win`) and type "cmd".  Choose the option labeled
 "Command Prompt".
 
-![Running cmd](/img/full-node/en-win10-running-cmd.png?{{site.time | date: '%s'}})
+![Running cmd](/img/full-node/en-win10-running-cmd.png)
 
 If you installed Bitcoin Core into the default directory, type the
 following at the command prompt:
@@ -764,7 +764,7 @@ daemon will be automatically started.
 Go to the [Bitcoin Core download page][] and verify you have
 made a secure connection to the server.
 
-![Verify secure connection](/img/full-node/en-secure-connection.png?{{site.time | date: '%s'}})
+![Verify secure connection](/img/full-node/en-secure-connection.png)
 
 Click the large blue *Download Bitcoin Core* button to download the
 Bitcoin Core installer to your desktop.
@@ -778,7 +778,7 @@ Bitcoin installer will start.  It's a typical Windows installer, and it will
 guide you through the decisions you need to make about where to install Bitcoin
 Core.
 
-![Windows 7 installer start](/img/full-node/en-win7-installer-start.png?{{site.time | date: '%s'}})
+![Windows 7 installer start](/img/full-node/en-win7-installer-start.png)
 
 <div class="box" markdown="1">
 *To continue, choose one of the following options*
@@ -804,20 +804,20 @@ Core.
 Press the Windows key (`⊞ Win`) and start typing "bitcoin".  When the
 Bitcoin Core icon appears (as shown below), click on it.
 
-![Starting Bitcoin Core](/img/full-node/en-win8-start-bitcoin-core.png?{{site.time | date: '%s'}})
+![Starting Bitcoin Core](/img/full-node/en-win8-start-bitcoin-core.png)
 
 You will be prompted to choose a directory to store the Bitcoin block
 chain and your wallet.  Unless you have a separate partition or drive
 you want to use, click Ok to use the default.
 
-![Bitcoin-Qt Welcome](/img/full-node/en-win7-welcome-to-bitcoin-core.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Welcome](/img/full-node/en-win7-welcome-to-bitcoin-core.png)
 
 Your firewall may block Bitcoin Core from making outbound connections.
 It's safe to allow Bitcoin Core to use all networks. (Note: you will
 still need to configure inbound connections as described later in the
 [Network Configuration](#network-configuration) section.)
 
-![Opening outgoing firewall for Bitcoin Core](/img/full-node/en-win7-bitcoin-core-outgoing-firewall.png?{{site.time | date: '%s'}})
+![Opening outgoing firewall for Bitcoin Core](/img/full-node/en-win7-bitcoin-core-outgoing-firewall.png)
 
 Bitcoin Core GUI will begin to download the block chain.  This step will take at
 least several days, and it may take much more time on a slow Internet connection
@@ -826,7 +826,7 @@ significant part of your connection bandwidth.  You can stop Bitcoin Core at any
 time by closing it; it will resume from the point where it stopped the next time
 you start it.
 
-![Bitcoin-Qt Initial Block Download](/img/full-node/en-win7-ibd.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Initial Block Download](/img/full-node/en-win7-ibd.png)
 
 After download is complete, you may use Bitcoin Core as your wallet or
 you can just let it run to help support the Bitcoin network.
@@ -842,7 +842,7 @@ While running Bitcoin Core GUI, open the Settings menu and choose
 Options.  On the Main tab, click *Start Bitcoin on system login*.  Click
 the Ok button to save the new settings.
 
-![Choosing to start Bitcoin Core at login](/img/full-node/en-win7-start-on-login.png?{{site.time | date: '%s'}})
+![Choosing to start Bitcoin Core at login](/img/full-node/en-win7-start-on-login.png)
 
 The next time you login to your desktop, Bitcoin Core GUI will be
 automatically started minimized in the task bar.
@@ -860,7 +860,7 @@ To start Bitcoin Core daemon, first open a command window: press the
 Windows key (`⊞ Win`) and type "cmd".  Choose the option labeled
 "Command Prompt".
 
-![Running cmd](/img/full-node/en-win8-running-cmd.png?{{site.time | date: '%s'}})
+![Running cmd](/img/full-node/en-win8-running-cmd.png)
 
 If you installed Bitcoin Core into the default directory, type the
 following at the command prompt:
@@ -918,7 +918,7 @@ daemon will be automatically started.
 Go to the [Bitcoin Core download page][] and verify you have
 made a secure connection to the server.
 
-![Verify secure connection](/img/full-node/en-secure-connection.png?{{site.time | date: '%s'}})
+![Verify secure connection](/img/full-node/en-secure-connection.png)
 
 Click the large blue *Download Bitcoin Core* button to download the
 Bitcoin Core installer to your desktop.
@@ -932,7 +932,7 @@ Bitcoin installer will start.  It's a typical Windows installer, and it will
 guide you through the decisions you need to make about where to install Bitcoin
 Core.
 
-![Windows 7 installer start](/img/full-node/en-win7-installer-start.png?{{site.time | date: '%s'}})
+![Windows 7 installer start](/img/full-node/en-win7-installer-start.png)
 
 <div class="box" markdown="1">
 *To continue, choose one of the following options*
@@ -958,20 +958,20 @@ Core.
 Open the *Start* menu, type `bitcoin` into the search box, and click the
 *Bitcoin Core* icon.
 
-![Start Bitcoin Core](/img/full-node/en-win7-start-bitcoin-core.png?{{site.time | date: '%s'}})
+![Start Bitcoin Core](/img/full-node/en-win7-start-bitcoin-core.png)
 
 You will be prompted to choose a directory to store the Bitcoin block
 chain and your wallet.  Unless you have a separate partition or drive
 you want to use, click Ok to use the default.
 
-![Bitcoin-Qt Welcome](/img/full-node/en-win7-welcome-to-bitcoin-core.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Welcome](/img/full-node/en-win7-welcome-to-bitcoin-core.png)
 
 Your firewall may block Bitcoin Core from making outbound connections.
 It's safe to allow Bitcoin Core to use all networks. (Note: you will
 still need to configure inbound connections as described later in the
 [Network Configuration](#network-configuration) section.)
 
-![Opening outgoing firewall for Bitcoin Core](/img/full-node/en-win7-bitcoin-core-outgoing-firewall.png?{{site.time | date: '%s'}})
+![Opening outgoing firewall for Bitcoin Core](/img/full-node/en-win7-bitcoin-core-outgoing-firewall.png)
 
 Bitcoin Core GUI will begin to download the block chain.  This step will take at
 least several days, and it may take much more time on a slow Internet connection
@@ -980,7 +980,7 @@ significant part of your connection bandwidth.  You can stop Bitcoin Core at any
 time by closing it; it will resume from the point where it stopped the next time
 you start it.
 
-![Bitcoin-Qt Initial Block Download](/img/full-node/en-win7-ibd.png?{{site.time | date: '%s'}})
+![Bitcoin-Qt Initial Block Download](/img/full-node/en-win7-ibd.png)
 
 After download is complete, you may use Bitcoin Core as your wallet or
 you can just let it run to help support the Bitcoin network.
@@ -996,7 +996,7 @@ While running Bitcoin Core GUI, open the Settings menu and choose
 Options.  On the Main tab, click *Start Bitcoin on system login*.  Click
 the Ok button to save the new settings.
 
-![Choosing to start Bitcoin Core at login](/img/full-node/en-win7-start-on-login.png?{{site.time | date: '%s'}})
+![Choosing to start Bitcoin Core at login](/img/full-node/en-win7-start-on-login.png)
 
 The next time you login to your desktop, Bitcoin Core GUI will be
 automatically started minimized in the task bar.
@@ -1013,7 +1013,7 @@ automatically started minimized in the task bar.
 To start Bitcoin Core daemon, first open a command window: press the
 Windows key (`⊞ Win`) and type "cmd". Choose the program named "cmd.exe"
 
-![Running cmd](/img/full-node/en-win7-running-cmd.png?{{site.time | date: '%s'}})
+![Running cmd](/img/full-node/en-win7-running-cmd.png)
 
 If you installed the Bitcoin Core into the default directory, type the following at the command prompt :
 
@@ -1080,7 +1080,7 @@ Save the file. The next time you login to your computer, Bitcoin Core daemon wil
 Go to the [Bitcoin Core download page][] and verify you have
 made a secure connection to the server.
 
-![Verify secure connection](/img/full-node/en-osx-safari-secure-connection.png?{{site.time | date: '%s'}})
+![Verify secure connection](/img/full-node/en-osx-safari-secure-connection.png)
 
 Click the large blue *Download Bitcoin Core* button to download the
 Bitcoin Core installer to your Downloads folder.
@@ -1092,7 +1092,7 @@ After downloading the file to your Downloads folder
 its icon. OS X will open a Finder window for you to drag *Bitcoin Core* to your
 Applications folder.
 
-![Window to install](/img/full-node/en-osx-dmg-open.png?{{site.time | date: '%s'}})
+![Window to install](/img/full-node/en-osx-dmg-open.png)
 
 #### Bitcoin Core GUI {#osx-gui}
 {:.no_toc}
@@ -1100,13 +1100,13 @@ Applications folder.
 The first time running *Bitcoin Core*, Max OS X will ask you to confirm that
 you want to run it:
 
-![Mac OS X File Security Dialog](/img/full-node/en-osx-security.png?{{site.time | date: '%s'}})
+![Mac OS X File Security Dialog](/img/full-node/en-osx-security.png)
 
 You will be prompted to choose a directory to store the Bitcoin block
 chain and your wallet.  Unless you have a separate partition or drive
 you want to use, click Ok to use the default.
 
-![Bitcoin Core Welcome](/img/full-node/en-osx-welcome-to-bitcoin-core.png?{{site.time | date: '%s'}})
+![Bitcoin Core Welcome](/img/full-node/en-osx-welcome-to-bitcoin-core.png)
 
 Bitcoin Core GUI will begin to download the block chain.  This step will take at
 least several days, and it may take much more time on a slow Internet connection
@@ -1115,7 +1115,7 @@ significant part of your connection bandwidth.  You can stop Bitcoin Core at any
 time by closing it; it will resume from the point where it stopped the next time
 you start it.
 
-![Bitcoin Core Initial Block Download](/img/full-node/en-osx-ibd.png?{{site.time | date: '%s'}})
+![Bitcoin Core Initial Block Download](/img/full-node/en-osx-ibd.png)
 
 After download is complete, you may use Bitcoin Core as your wallet or
 you can just let it run to help support the Bitcoin network.
@@ -1131,7 +1131,7 @@ While running Bitcoin Core GUI, open the Bitcoin Core menu and choose
 Preferences.  On the Main tab, click *Start Bitcoin on system login*.  Click
 the Ok button to save the new settings.
 
-![Choosing to start Bitcoin Core at login](/img/full-node/en-osx-start-on-login.png?{{site.time | date: '%s'}})
+![Choosing to start Bitcoin Core at login](/img/full-node/en-osx-start-on-login.png)
 
 The next time you login to your desktop, Bitcoin Core GUI will be
 automatically started minimized in the task bar.
@@ -1230,7 +1230,7 @@ start Bitcoin Core (either the GUI or the daemon), wait 10 minutes, and then
 will attempt to guess your IP address---if the address is wrong (or
 blank), you will need to enter your address manually.
 
-![Bitnodes Tool](/img/full-node/en-bitnodes-tool.png?{{site.time | date: '%s'}})
+![Bitnodes Tool](/img/full-node/en-bitnodes-tool.png)
 
 After you press Check Node, the tool will inform you whether your port
 is open (green box) or not open (red box). If you get the green box, you
@@ -1259,14 +1259,14 @@ connections you have. The icon won't turn green until you have more
 than 8 active connections, which only happens if inbound connections
 are allowed.
 
-![Active connections](/img/full-node/en-active-connections.png?{{site.time | date: '%s'}})
+![Active connections](/img/full-node/en-active-connections.png)
 
 For confirmation, you can go to the Help menu, choose Debug Window, and
 open the Information tab. In the Network section, it will tell you
 exactly how many inbound connections you have. If the number is greater
 than zero, then inbound connections are allowed.
 
-![Debug window with inbound connections](/img/full-node/en-debug-inbound-connections.png?{{site.time | date: '%s'}})
+![Debug window with inbound connections](/img/full-node/en-debug-inbound-connections.png)
 
 If you don't have inbound connections, please read the instructions for [enabling inbound
 connections.](#enabling-connections)
@@ -1340,13 +1340,13 @@ related to DHCP, the Dynamic Host Configuration Protocol.  These options
 may also be called Address Reservation.  For example, the router page
 shown below calls the option we need "DHCP Reservation":
 
-![DHCP reservation button](/img/full-node/en-dhcp-reservation.png?{{site.time | date: '%s'}})
+![DHCP reservation button](/img/full-node/en-dhcp-reservation.png)
 
 In the reservation configuration, some routers will display a list of
 computers and devices currently connected to your network, and then let
 you select a device to make its current IP address permanent:
 
-![Easy DHCP reservation](/img/full-node/en-easy-dhcp-reservation.png?{{site.time | date: '%s'}})
+![Easy DHCP reservation](/img/full-node/en-easy-dhcp-reservation.png)
 
 If that's the case, find the computer running Bitcoin Core in the list,
 select it, and add it to the list of reserved addresses. Make a note of
@@ -1386,7 +1386,7 @@ address and make a note of it for the instructions in the next
 subsection. After entering this information, click the Add or Save
 button.
 
-![Manual DHCP reservation](/img/full-node/en-manual-dhcp-reservation.png?{{site.time | date: '%s'}})
+![Manual DHCP reservation](/img/full-node/en-manual-dhcp-reservation.png)
 
 Then reboot your computer to ensure it gets assigned the address you
 selected and proceed to the Port Forwarding instructions below.
@@ -1406,7 +1406,7 @@ The port forwarding settings should allow you to map an external port on
 your router to the "internal port" of a device on your network as shown
 in the screenshot below.
 
-![Port forwarding](/img/full-node/en-port-forwarding.png?{{site.time | date: '%s'}})
+![Port forwarding](/img/full-node/en-port-forwarding.png)
 
 Both the external port and the internal port should be 8333 for Bitcoin.
 (You may also want to map port 18333 for Bitcoin's testnet, although

--- a/en/rss/alerts.rss
+++ b/en/rss/alerts.rss
@@ -12,7 +12,7 @@ lang: en
 	<description>This RSS feed allows to follow events and alerts surrounding the Bitcoin network and software.</description>
 	<image>
 		<title>Bitcoin network status and alerts</title>
-		<url>{{site.url}}/img/icons/logo_rss.png?1528322191</url>
+		<url>{{site.url}}/img/icons/logo_rss.png</url>
 		<link>{{site.url}}/en/alerts</link>
 	</image>
         {% assign date_sorted_alerts = site.alerts | sort: 'date' %}

--- a/en/rss/blog.xml
+++ b/en/rss/blog.xml
@@ -12,8 +12,8 @@ lang: en
     <description>News about {{site.name}}</description>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ "/en/rss/blog.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
-    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
-    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    <pubDate>{{ site.posts[0].date | date_to_rfc822 }}</pubDate>
+    <lastBuildDate>{{ site.posts[0].date | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
     {% for post in site.posts limit:5 %}
       <item>


### PR DESCRIPTION
This PR makes the site builds deterministic again. The two sources of non-determinism were the cache busting technique, and the `pubDate` and `lastBuildDate` from the blog's RSS feed.

To address the first source of non-determinism, the cache busting technique was simply removed. This technique involved appending the build timestamp to every image and css file loaded. Since the site is largely static and images and css are unlikely to be constantly changing, I do not think it is necessary to keep this technique around. Removing it also makes the site build deterministically.

To address second source of non-determinism, the `pubDate` and `lastBuildDate` fields of the blog's RSS feed have been changed from the actual build date to the date of the most recent blog post. This makes the builds deterministic while also ensuring the the RSS feed will be updated when new blog posts are made.

This addresses the second point of #14.